### PR TITLE
大佬，发现您的项目引入了com.fasterxml.jackson.core:jackson-databind@2.9.9组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.axxc</groupId>
 	<artifactId>replicator</artifactId>
@@ -19,7 +18,7 @@
 		<commons-lang3.version>3.8.1</commons-lang3.version>
 		<commons-beanutils.version>1.9.3</commons-beanutils.version>
 		<logback-classic.version>1.2.6</logback-classic.version>
-		<jackson-databind.version>2.13.0</jackson-databind.version>
+		<jackson-databind.version>2.9.10.8</jackson-databind.version>
 		<disruptor.version>3.4.4</disruptor.version>
 		<mysql-binlog-connector-java.version>0.25.0</mysql-binlog-connector-java.version>
 		<spring.version>5.1.9.RELEASE</spring.version>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：FasterXML jackson-databind 代码问题漏洞
缺陷组件：com.fasterxml.jackson.core:jackson-databind@2.9.9
漏洞编号：CVE-2019-14893
漏洞描述：FasterXML jackson-databind是一个基于JAVA可以将XML和JSON等数据格式与JAVA对象进行转换的库。Jackson可以轻松的将Java对象转换成json对象和xml文档，同样也可以将json、xml转换成Java对象。
FasterXML jackson-databind 2.8.11.5之前版本和2.9.0版本及之后版本（2.9.10版本已修复）中存在代码问题漏洞。攻击者可利用该漏洞执行任意代码。
影响范围：[2.9.0, 2.9.10.3)
最小修复版本：2.9.10.8
缺陷组件引入路径：com.axxc:replicator-example@0.0.1-SNAPSHOT->org.springframework.boot:spring-boot-starter-web@2.1.7.RELEASE->org.springframework.boot:spring-boot-starter-json@2.1.7.RELEASE->com.fasterxml.jackson.core:jackson-databind@2.9.9
```
另外我运行这个项目时，IDE的安全插件提示还有67个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p98f74